### PR TITLE
Compinit all the time

### DIFF
--- a/default.zshrc
+++ b/default.zshrc
@@ -103,8 +103,8 @@ if [[ $(command -v helm) ]]; then
   source <(helm completion zsh | sed -E 's/\["(.+)"\]/\[\1\]/g')
 fi
 
+autoload bashcompinit && bashcompinit
 if [[ $(command -v az) && -f "/usr/local/etc/bash_completion.d/az" ]]; then
-  autoload bashcompinit && bashcompinit
   source /usr/local/etc/bash_completion.d/az
 fi
 


### PR DESCRIPTION
This ensures that autocompletion is enabled, even if the azure dev tools aren't available